### PR TITLE
added timeZoneID as settable option

### DIFF
--- a/adapters/Smx/SimpleMeetings/WebEx/Meeting.php
+++ b/adapters/Smx/SimpleMeetings/WebEx/Meeting.php
@@ -32,6 +32,7 @@ class Meeting extends Account implements \Smx\SimpleMeetings\Interfaces\Meeting
     public $hostUrl = null;
     public $joinUrl = null;
     public $exitUrl = false;
+    public $timeZoneID = null;
     
     /**
      * History details is an array of the actual meeting usage data for a meeting
@@ -83,6 +84,9 @@ class Meeting extends Account implements \Smx\SimpleMeetings\Interfaces\Meeting
         $xml->body->bodyContent->accessControl->enforcePassword = $this->enforcePassword;
         if(!is_null($this->meetingPassword)){
             $xml->body->bodyContent->accessControl->meetingPassword = $this->meetingPassword;
+        }
+        if(!is_null($this->timeZoneID)) {
+            $xml->body->bodyContent->schedule->timeZoneID = $this->timeZoneID;
         }
         
         $result = $this->callApi($xml->asXML());
@@ -279,6 +283,9 @@ class Meeting extends Account implements \Smx\SimpleMeetings\Interfaces\Meeting
         $xml->body->bodyContent->accessControl->enforcePassword = $this->enforcePassword;
         if(!is_null($this->meetingPassword)){
             $xml->body->bodyContent->accessControl->meetingPassword = $this->meetingPassword;
+        }
+        if(!is_null($this->timeZoneID)) {
+            $xml->body->bodyContent->schedule->timeZoneID = $this->timeZoneID;
         }
         
         $result = $this->callApi($xml->asXML());


### PR DESCRIPTION
as mentioned in issue #2 

webex timeZoneIDs:
http://docwiki.cisco.com/wiki/Cisco_Unified_MeetingPlace,_Release_7.0_--_Time_Zone_Mapping_Between_Cisco_WebEx_and_Cisco_Unified_MeetingPlace